### PR TITLE
<feat>: implmented TactJam-firmware#3 record mode and TactJam-firmware#5 play mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "TACT/lib/libvtp"]
+	path = TACT/lib/libvtp
+	url = https://github.com/lhinderberger/libvtp.git

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ If you are looking for the software that drives the device, you have come to the
 
 ## How to build and develop the firmware
 
-The TactJam hardware is based on the [ESP32 MCU by Espressif](https://www.espressif.com/en/products/socs/esp32/overview). To simplify the embedded development we use [PlatformIO](https://platformio.org/). For the sake of convience the code editor [VSCodium](https://vscodium.com/) offers a package for PlatformIO. Please refer to the [installation guide](https://docs.platformio.org/en/latest/integration/ide/vscode.html#installation) for details. Of course you can also use other editors (see the [list of supported editors](https://docs.platformio.org/en/latest/integration/ide/index.html#desktop-ide)), or use only the [CLI](https://docs.platformio.org/en/latest/core/index.html).
+The TactJam hardware is based on the [ESP32 MCU by Espressif](https://www.espressif.com/en/products/socs/esp32/overview). To simplify the embedded development we use [PlatformIO](https://platformio.org/). For the sake of convience the code editor [VSCodium](https://vscodium.com/) offers a package for PlatformIO. Please refer to the [installation guide](https://docs.platformio.org/en/latest/integration/ide/vscode.html#installation) for details. Of course you can also use other editors (see the [list of supported editors](https://docs.platformio.org/en/latest/integration/ide/index.html#desktop-ide)), or use only the [CLI](https://docs.platformio.org/en/latest/core/index.html). The firmware code includes [libvtp](https://github.com/lhinderberger/libvtp) as submoule. To include submodules during clone you can use the command `git clone --recurse-submodules https://github.com/TactileVision/TactJam-firmware.git`.
+
 
 
 ### Configuration

--- a/TACT/include/PCA9685.h
+++ b/TACT/include/PCA9685.h
@@ -10,6 +10,7 @@ class PCA9685 {
     uint8_t address_;
     float frequency_;
     bool initialized_;
+    uint8_t active_positions_old;
 
   public:
     PCA9685();

--- a/TACT/include/buzzer.h
+++ b/TACT/include/buzzer.h
@@ -87,6 +87,10 @@ class Buzzer {
      * 
      */
     void PlayInitSequence();
+
+    void PlayConfirm();
+
+    void PlayFail();
 #endif //__TACT_BUZZER_MULTIPLEXER__
 };
 

--- a/TACT/include/buzzer.h
+++ b/TACT/include/buzzer.h
@@ -52,6 +52,10 @@ class Buzzer {
      * 
      */
     void PlayInitSequence();
+
+    void PlayConfirm();
+
+    void PlayFail();
 #else
     Buzzer() = delete;
     Buzzer(uint8_t pin, uint8_t pwm_channel = 0);

--- a/TACT/include/config.h
+++ b/TACT/include/config.h
@@ -17,7 +17,7 @@ const auto kDebugLevel = (TACT_DEBUG == 1) ? DebugLevel::basic : DebugLevel::ver
 const auto kSerialBaudRate = 115200;
 const uint8_t kInitializationDelay = 20;
 
-const uint8_t kERMOverdriveDuration = 40;
+const uint8_t kERMOverdriveDuration = 20;
 
 // The dev-board v0.2 has the buzzer attached to the PWM multiplexer.
 // TODO: remove definition for final board

--- a/TACT/include/config.h
+++ b/TACT/include/config.h
@@ -26,6 +26,11 @@ const uint8_t kERMOverdriveDuration = 20;
 const uint8_t kBuzzerID = 8;
 #endif
 
+#if TACT_BOARD_REV==0
+const uint8_t kActuatorMapping[] = {0,1,2,3,4,5,6,7};
+#elif TACT_BOARD_REV==1
+const uint8_t kActuatorMapping[] = {0,1,2,3,8,9,10,11};
+#endif //TACT_BOARD_REV
 
 namespace esp {
 namespace pins {

--- a/TACT/include/display.h
+++ b/TACT/include/display.h
@@ -154,21 +154,17 @@ class Display {
      * 
      * @param text the text to display.
      */
-    void DrawContentTeaser(const String& text);
-
-    /**
-     * @brief Display a large teaser message in the center of the content section.
-     * 
-     * @param text the text to display.
-     */
     void DrawContentTeaserSingleLine(const String& text);
 
     /**
      * @brief Display a large teaser message in the center of the content section.
      * 
-     * @param text the text to display.
+     * @param line_1 the text to display.
+     * @param line_2 the text to display.
      */
     void DrawContentTeaserDoubleLine(const String& line_1, const String& line_2);
+
+    void ClearContentTeaser();
 
     // TODO: This method declaration may change depending on the information we need to display.
     /**

--- a/TACT/include/display.h
+++ b/TACT/include/display.h
@@ -156,6 +156,20 @@ class Display {
      */
     void DrawContentTeaser(const String& text);
 
+    /**
+     * @brief Display a large teaser message in the center of the content section.
+     * 
+     * @param text the text to display.
+     */
+    void DrawContentTeaserSingleLine(const String& text);
+
+    /**
+     * @brief Display a large teaser message in the center of the content section.
+     * 
+     * @param text the text to display.
+     */
+    void DrawContentTeaserDoubleLine(const String& line_1, const String& line_2);
+
     // TODO: This method declaration may change depending on the information we need to display.
     /**
      * @brief Display detailed information of a given tacton.

--- a/TACT/include/linearEncoder.h
+++ b/TACT/include/linearEncoder.h
@@ -47,6 +47,14 @@ class LinearEncoder {
     uint8_t GetPercent(bool update = true);
 
     /**
+     * @brief Get the amplitude from percent.
+     * 
+     * @param percent Percent value to be converted
+     * @return uint16_t the amplitude
+     */
+    uint16_t PercentToLinearEncoder(uint8_t percent);
+
+    /**
      * @brief  Get the amplitude as 8bit value (0-255).
      * 
      * @param update If true a new measurement is taken before returning the value.

--- a/TACT/include/tactons.h
+++ b/TACT/include/tactons.h
@@ -1,0 +1,61 @@
+#ifndef _TACT_TACTONS_
+#define _TACT_TACTONS_
+
+#include <Arduino.h>
+#include <vector>
+#include "buzzer.h"
+#include "PCA9685.h"
+#include "SN74HC595.h"
+#include "linearEncoder.h"
+#include "state.h"
+
+namespace tact {
+
+//#define TACTON_SAMPLES_MAX 10000
+#define TACTONS_COUNT_MAX 8
+
+class TactonSample {
+  public:
+    uint32_t time_milliseconds = 0;
+    uint8_t buttons_state = 0;
+    uint8_t amplitude_percent = 0;
+
+    void SerialPrint(void);
+};
+
+class Tacton {
+  public:
+    std::vector<TactonSample> tacton_samples;
+};
+
+class TactonRecorderPlayer {
+  public:
+    enum class State {
+      idle,
+      recording,
+      playing
+    };
+
+    TactonRecorderPlayer();
+
+    void Reset(void);
+    void RecordButtonPressed(tact::State &current_state, tact::Buzzer &buzzer);
+    void PlayButtonPressed(tact::Buzzer &buzzer);
+    void RecordSample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, tact::SN74HC595 &button_leds);
+    void PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, 
+                    tact::SN74HC595 &button_leds, tact::LinearEncoder &amplitude_encoder);
+
+
+  private:
+    std::vector<Tacton> tactons;
+
+    unsigned long time_start_milliseconds = 0;
+    uint32_t index_play_next = 0;
+    State state = State::idle;
+};
+
+
+} //namespace tact
+
+
+#endif //_TACT_TACTONS_

--- a/TACT/include/tactons.h
+++ b/TACT/include/tactons.h
@@ -43,6 +43,7 @@ class TactonRecorderPlayer {
     void Reset();
     void RecordButtonPressed(tact::State &current_state, tact::Buzzer &buzzer);
     void PlayButtonPressed(tact::Buzzer &buzzer);
+    void LoopButtonPressed(tact::Buzzer &buzzer);
     void RecordSample(tact::State &current_state, tact::Buzzer &buzzer);
     void PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::LinearEncoder &amplitude_encoder);
 
@@ -56,6 +57,7 @@ class TactonRecorderPlayer {
     unsigned long time_start_milliseconds = 0;
     uint32_t index_play_next = 0;
     State state = State::idle; // use method SetState to change the state
+    bool loop_playback = false;
 };
 
 

--- a/TACT/include/tactons.h
+++ b/TACT/include/tactons.h
@@ -10,6 +10,10 @@
 #include "display.h"
 #include "state.h"
 
+extern "C" {
+#include <vtp/codec.h>
+}
+
 namespace tact {
 
 //#define TACTON_SAMPLES_MAX 10000
@@ -47,6 +51,12 @@ class TactonRecorderPlayer {
     void RecordSample(tact::State &current_state, tact::Buzzer &buzzer);
     void PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::LinearEncoder &amplitude_encoder);
 
+    void ToVTP(uint8_t slot);
+    void TransferVTPInstructionToPC(VTPInstructionWord* encodedInstructionWord);
+    /**
+     *  @param index_of_instruction used for initialisation if index is 0 and may be used for debugging
+     */
+    void FromVTP(uint8_t slot, VTPInstructionWord* encodedInstructionWord, uint32_t index_of_instruction);
 
   private:
     std::vector<Tacton> tactons;
@@ -58,6 +68,10 @@ class TactonRecorderPlayer {
     uint32_t index_play_next = 0;
     State state = State::idle; // use method SetState to change the state
     bool loop_playback = false;
+
+    //VTP based variables
+    unsigned long time_vtp_instruction_milliseconds = 0;
+    uint32_t index_vtp_instruction = 0;
 };
 
 

--- a/TACT/include/tactons.h
+++ b/TACT/include/tactons.h
@@ -7,6 +7,7 @@
 #include "PCA9685.h"
 #include "SN74HC595.h"
 #include "linearEncoder.h"
+#include "display.h"
 #include "state.h"
 
 namespace tact {
@@ -36,22 +37,25 @@ class TactonRecorderPlayer {
       playing
     };
 
-    TactonRecorderPlayer();
+    TactonRecorderPlayer(tact::Display* display, PCA9685* actuator_driver, SN74HC595* button_leds);
 
-    void Reset(void);
+    void SetState(State state, bool force_display_update = false);
+    void Reset();
     void RecordButtonPressed(tact::State &current_state, tact::Buzzer &buzzer);
     void PlayButtonPressed(tact::Buzzer &buzzer);
-    void RecordSample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, tact::SN74HC595 &button_leds);
-    void PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, 
-                    tact::SN74HC595 &button_leds, tact::LinearEncoder &amplitude_encoder);
+    void RecordSample(tact::State &current_state, tact::Buzzer &buzzer);
+    void PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::LinearEncoder &amplitude_encoder);
 
 
   private:
     std::vector<Tacton> tactons;
+    Display* display;
+    PCA9685* actuator_driver;
+    SN74HC595* button_leds;
 
     unsigned long time_start_milliseconds = 0;
     uint32_t index_play_next = 0;
-    State state = State::idle;
+    State state = State::idle; // use method SetState to change the state
 };
 
 

--- a/TACT/src/PCA9685.cpp
+++ b/TACT/src/PCA9685.cpp
@@ -43,6 +43,7 @@ void PCA9685::Update(uint8_t active_positions, uint16_t amplitude, bool enable_o
     for (uint8_t idx = 0; idx < 8; idx++) {
       pwm_driver_->setPWM(7-idx, 0, 0);
     }
+    active_positions_old = active_positions;
     return;
   }
   if (enable_overdrive) {

--- a/TACT/src/PCA9685.cpp
+++ b/TACT/src/PCA9685.cpp
@@ -38,16 +38,26 @@ void PCA9685::Update(uint8_t active_positions, uint16_t amplitude, bool enable_o
   if (!initialized_) {
     Initialize();
   }
+  if (active_positions == 0 || amplitude == 0) {
+    for (uint8_t idx = 0; idx < 8; idx++) {
+      pwm_driver_->setPWM(7-idx, 0, 0);
+    }
+    return;
+  }
+  if (enable_overdrive) {
+    for (uint8_t idx = 0; idx < 8; idx++) {
+      if (((active_positions >> idx)%2) == 1) {
+        pwm_driver_->setPWM(7-idx, 0, kMaxAmplitude);
+      }
+    }
+    // TODO delay may interfer with the control flow
+    // find a better solution
+    delay(config::kERMOverdriveDuration);
+  }
   for (uint8_t idx = 0; idx < 8; idx++) {
     if (((active_positions >> idx)%2) == 0) {
       pwm_driver_->setPWM(7-idx, 0, 0);
     } else {
-      if (enable_overdrive) {
-        pwm_driver_->setPWM(7-idx, 0, kMaxAmplitude);
-        // TODO delay may interfer with the control flow
-        // find a better solution
-        delay(config::kERMOverdriveDuration);
-      }
       pwm_driver_->setPWM(7-idx, 0, amplitude);
     }
   }

--- a/TACT/src/PCA9685.cpp
+++ b/TACT/src/PCA9685.cpp
@@ -41,7 +41,7 @@ void PCA9685::Update(uint8_t active_positions, uint16_t amplitude, bool enable_o
   }
   if (active_positions == 0 || amplitude == 0) {
     for (uint8_t idx = 0; idx < 8; idx++) {
-      pwm_driver_->setPWM(7-idx, 0, 0);
+      pwm_driver_->setPWM(config::kActuatorMapping[7-idx], 0, 0);
     }
     active_positions_old = active_positions;
     return;
@@ -51,7 +51,7 @@ void PCA9685::Update(uint8_t active_positions, uint16_t amplitude, bool enable_o
     for (uint8_t idx = 0; idx < 8; idx++) {
       if ((((active_positions_old >> idx)%2) == 0) &&
          ((active_positions >> idx)%2) == 1) {
-        pwm_driver_->setPWM(7-idx, 0, kMaxAmplitude);
+        pwm_driver_->setPWM(config::kActuatorMapping[7-idx], 0, kMaxAmplitude);
         overdrive_activated = true;
       }
     }
@@ -62,9 +62,9 @@ void PCA9685::Update(uint8_t active_positions, uint16_t amplitude, bool enable_o
   }
   for (uint8_t idx = 0; idx < 8; idx++) {
     if (((active_positions >> idx)%2) == 0) {
-      pwm_driver_->setPWM(7-idx, 0, 0);
+      pwm_driver_->setPWM(config::kActuatorMapping[7-idx], 0, 0);
     } else {
-      pwm_driver_->setPWM(7-idx, 0, amplitude);
+      pwm_driver_->setPWM(config::kActuatorMapping[7-idx], 0, amplitude);
     }
   }
   active_positions_old = active_positions;

--- a/TACT/src/buzzer.cpp
+++ b/TACT/src/buzzer.cpp
@@ -60,6 +60,18 @@ void Buzzer::PlayInitSequence() {
   NoTone(50);
 }
 
+void Buzzer::PlayConfirm() {
+  Tone(50);
+  NoTone(10);
+}
+
+void Buzzer::PlayFail() {
+  Tone(150);
+  NoTone(20);
+  Tone(150);
+  NoTone(20);
+}
+
 #else
 
 Buzzer::Buzzer(uint8_t pin, uint8_t pwm_channel) {

--- a/TACT/src/buzzer.cpp
+++ b/TACT/src/buzzer.cpp
@@ -124,6 +124,18 @@ void Buzzer::PlayInitSequence() {
   Tone(500, 300);
   NoTone(100);
 }
+
+void Buzzer::PlayConfirm() {
+  Tone(50, 100);
+  NoTone(10);
+}
+
+void Buzzer::PlayFail() {
+  Tone(150, 100);
+  NoTone(20);
+  Tone(150, 100);
+  NoTone(20);
+}
 #endif //__TACT_BUZZER_MULTIPLEXER__
 
 }

--- a/TACT/src/display.cpp
+++ b/TACT/src/display.cpp
@@ -81,6 +81,51 @@ void Display::DrawAmplitude(uint8_t amplitude_perc) {
 }
 
 
+void Display::DrawContentTeaserSingleLine(const String& text) {
+  if (!initialized_ && !Initialize()) {
+    return;
+  }
+  ClearContent();
+  SSD1306_->invertDisplay(false);
+  SSD1306_->setTextColor(SSD1306_WHITE);
+  SSD1306_->setTextSize(2);
+  int16_t x = kContentSpacing;
+  auto text_width = text.length() * kCharWidth * 2;
+  if (text_width < kContentWidth) {
+    x = (kWidth - text_width) / 2;
+  }
+  SSD1306_->setCursor(x, kContentOffsetTop + kLineHeight);
+  SSD1306_->println(text);
+  SSD1306_->display();
+}
+
+
+void Display::DrawContentTeaserDoubleLine(const String& line_1, const String& line_2) {
+  if (!initialized_ && !Initialize()) {
+    return;
+  }
+  ClearContent();
+
+  SSD1306_->invertDisplay(false);
+  SSD1306_->setTextColor(SSD1306_WHITE);
+  SSD1306_->setTextSize(2);
+  int16_t x = kContentSpacing;
+  auto text_width = line_1.length() * kCharWidth * 2;
+  if (text_width < kContentWidth) {
+    x = (kWidth - text_width) / 2;
+  }
+  SSD1306_->setCursor(x, kContentOffsetTop + kContentSpacing);
+  SSD1306_->println(line_1);
+  text_width = line_2.length() * kCharWidth * 2;
+  if (text_width < kContentWidth) {
+    x = (kWidth - text_width) / 2;
+  }
+  SSD1306_->setCursor(x, kContentOffsetTop + 2*kLineHeight + kSpacing);
+  SSD1306_->println(line_2);
+  SSD1306_->display();
+}
+
+
 void Display::DrawContentTeaser(const String& text) {
   if (!initialized_ && !Initialize()) {
     return;

--- a/TACT/src/display.cpp
+++ b/TACT/src/display.cpp
@@ -114,6 +114,7 @@ void Display::DrawTactonDetails(const uint8_t slot, const String& uuid, uint32_t
   SSD1306_->printf("length (ms):  %u\n", (uint32_t)length_millis);
   SSD1306_->setCursor(kContentSpacing, SSD1306_->getCursorY()+kSpacing);
   SSD1306_->printf("length (s):   %u\n", (uint32_t)(length_millis/1000));
+  SSD1306_->display();
 }
 
 

--- a/TACT/src/display.cpp
+++ b/TACT/src/display.cpp
@@ -125,25 +125,6 @@ void Display::DrawContentTeaserDoubleLine(const String& line_1, const String& li
   SSD1306_->display();
 }
 
-
-void Display::DrawContentTeaser(const String& text) {
-  if (!initialized_ && !Initialize()) {
-    return;
-  }
-  ClearContent();
-  SSD1306_->invertDisplay(false);
-  SSD1306_->setTextColor(SSD1306_WHITE);
-  SSD1306_->setTextSize(2);
-  int16_t x = kContentSpacing;
-  auto text_width = text.length() * kCharWidth * 2;
-  if (text_width < kContentWidth) {
-    x = (kWidth - text_width) / 2;
-  }
-  SSD1306_->setCursor(x, kContentOffsetTop);
-  SSD1306_->println(text);
-  SSD1306_->display();
-}
-
 // TODO: This method declaration may change depending on the information we need to display.
 void Display::DrawTactonDetails(const uint8_t slot, const String& uuid, uint32_t instruction_size, uint64_t length_millis) {
   ClearContent();
@@ -159,6 +140,12 @@ void Display::DrawTactonDetails(const uint8_t slot, const String& uuid, uint32_t
   SSD1306_->printf("length (ms):  %u\n", (uint32_t)length_millis);
   SSD1306_->setCursor(kContentSpacing, SSD1306_->getCursorY()+kSpacing);
   SSD1306_->printf("length (s):   %u\n", (uint32_t)(length_millis/1000));
+  SSD1306_->display();
+}
+
+
+void Display::ClearContentTeaser() {
+  ClearContent();
   SSD1306_->display();
 }
 

--- a/TACT/src/linearEncoder.cpp
+++ b/TACT/src/linearEncoder.cpp
@@ -42,6 +42,11 @@ uint8_t LinearEncoder::GetPercent(bool update) {
 }
 
 
+uint16_t LinearEncoder::PercentToLinearEncoder(uint8_t percent) {
+  return map(percent, 0, 100, 0, 4095);
+}
+
+
 uint8_t LinearEncoder::Get8bit(bool update) {
   if (update) {
     Read();

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -197,6 +197,7 @@ void HandleJamMode() {
     actuator_driver.Update(current_state.pressed_actuator_buttons, current_state.amplitude);
   }
 
+  // TODO: check if delay is needed
   delay(2);
 }
 
@@ -237,6 +238,7 @@ void HandleRecPlayMode() {
   //Serial.println("Record and Play Mode is not implemented yet");
   //#endif //TACT_DEBUG
 
+  // TODO: check if delay is needed
   delay(2);
 }
 

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -146,7 +146,7 @@ void loop() {
     current_state.mode != previous_state.mode) {
     actuator_driver.Update(0, 0);
     button_leds.Update(0);
-    display.DrawContentTeaser(""); // clear screen
+    display.ClearContentTeaser();
   }
 
   switch (current_state.mode) {

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -240,6 +240,10 @@ void HandleRecPlayMode() {
   if (previous_state.pressed_actuator_buttons != current_state.pressed_actuator_buttons) {
     tactonRecorderPlayer.RecordSample(current_state, buzzer);
   }
+  if (previous_state.amplitude != current_state.amplitude &&
+    current_state.pressed_actuator_buttons != 0) {
+    tactonRecorderPlayer.RecordSample(current_state, buzzer);
+  }
   tactonRecorderPlayer.PlaySample(current_state, buzzer, amplitude_encoder);
 
 

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -210,10 +210,7 @@ void HandleJamMode() {
 
 
 void HandleRecPlayMode() {
-  // TODO: play selected tacton (#5): https://github.com/TactileVision/TactJam-firmware/issues/5
-      // TODO: toggle loop mode (#9): https://github.com/TactileVision/TactJam-firmware/issues/9
-  // TODO: record tacton (#3): https://github.com/TactileVision/TactJam-firmware/issues/3
-      // TODO: amplitude modulation after recording (#10): https://github.com/TactileVision/TactJam-firmware/issues/10
+  // TODO: amplitude modulation after recording (#10): https://github.com/TactileVision/TactJam-firmware/issues/10
   // TODO: delete current tacton (#12): https://github.com/TactileVision/TactJam-firmware/issues/12
   ReadButtons();
 
@@ -259,8 +256,17 @@ void HandleRecPlayMode() {
 void HandleDataTransferMode() {
   // TODO: receive tacton from PC (#7): https://github.com/TactileVision/TactJam-firmware/issues/7
   // TODO: send tacton to PC (#8): https://github.com/TactileVision/TactJam-firmware/issues/8
+  ReadButtons();
+  if (previous_state.pressed_menu_buttons != current_state.pressed_menu_buttons) {
+    if ( (previous_state.pressed_menu_buttons & 4) == 4) {
+      //menu button 1 pressed
+      buzzer.PlayConfirm();
+      tactonRecorderPlayer.ToVTP(current_state.slot);
+      buzzer.PlayConfirm();
+    }
+  }
   #ifdef TACT_DEBUG
-  Serial.println("Transfer Mode is not implemented yet");
+  //Serial.println("Transfer Mode is not implemented yet");
   #endif //TACT_DEBUG
-  delay(2000);
+  delay(2);
 }

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -35,7 +35,7 @@ tact::Buzzer buzzer;
 #else
 tact::Buzzer buzzer(tact::config::esp::pins::kBuzzer);
 #endif
-tact::TactonRecorderPlayer tactonRecorderPlayer;
+tact::TactonRecorderPlayer tactonRecorderPlayer(&display, &actuator_driver, &button_leds);
 
 
 /**
@@ -142,6 +142,13 @@ void loop() {
     #endif //TACT_DEBUG
   }
 
+  if (current_state.slot != previous_state.slot ||
+    current_state.mode != previous_state.mode) {
+    actuator_driver.Update(0, 0);
+    button_leds.Update(0);
+    display.DrawContentTeaser(""); // clear screen
+  }
+
   switch (current_state.mode) {
     case tact::Modes::undefined :
       #ifdef TACT_DEBUG
@@ -213,8 +220,6 @@ void HandleRecPlayMode() {
   if (current_state.slot != previous_state.slot ||
     current_state.mode != previous_state.mode) {
     tactonRecorderPlayer.Reset();
-    actuator_driver.Update(0, 0);
-    button_leds.Update(0);
   }
 
   if (previous_state.pressed_menu_buttons != current_state.pressed_menu_buttons) {
@@ -229,9 +234,9 @@ void HandleRecPlayMode() {
   }
 
   if (previous_state.pressed_actuator_buttons != current_state.pressed_actuator_buttons) {
-    tactonRecorderPlayer.RecordSample(current_state, buzzer, actuator_driver, button_leds);
+    tactonRecorderPlayer.RecordSample(current_state, buzzer);
   }
-  tactonRecorderPlayer.PlaySample(current_state, buzzer, actuator_driver, button_leds, amplitude_encoder);
+  tactonRecorderPlayer.PlaySample(current_state, buzzer, amplitude_encoder);
 
 
   //#ifdef TACT_DEBUG

--- a/TACT/src/main.cpp
+++ b/TACT/src/main.cpp
@@ -231,6 +231,10 @@ void HandleRecPlayMode() {
       //menu button 1 pressed, start record
       tactonRecorderPlayer.PlayButtonPressed(buzzer);
     }
+    if ( (previous_state.pressed_menu_buttons & 1) == 1) {
+      //menu button 3 pressed, switch loop
+      tactonRecorderPlayer.LoopButtonPressed(buzzer);
+    }
   }
 
   if (previous_state.pressed_actuator_buttons != current_state.pressed_actuator_buttons) {

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -17,25 +17,26 @@ TactonRecorderPlayer::TactonRecorderPlayer(tact::Display* display, PCA9685* actu
 
 void TactonRecorderPlayer::SetState(State state, bool force_display_update) {
   if (state != this->state || force_display_update == true) {
+    std::string line_1;
+    std::string line_2;
     switch(state) {
       case State::idle: 
-        
-        //if ( loop_playback == true )
-        //  display->DrawContentTeaser("idle");
-        //else
-          display->DrawContentTeaserSingleLine("idle");
+        line_1.assign("idle");
         actuator_driver->Update(0, 0);
         button_leds->Update(0);
         break;
       case State::playing:
-        if ( loop_playback == true )
-          display->DrawContentTeaserDoubleLine("play", "loop on");
-        else
-          display->DrawContentTeaserDoubleLine("play", "loop off");
+        line_1.assign("play");
         break;
-      case State::recording: display->DrawContentTeaserSingleLine("rec");
+      case State::recording:
+        line_1.assign("rec");
         break;
     }
+    if ( loop_playback == true )
+      line_2.assign("loop on");
+    else
+      line_2.assign("loop off");
+    display->DrawContentTeaserDoubleLine(line_1.c_str(), line_2.c_str());
   }
   this->state = state;
 }
@@ -86,8 +87,8 @@ void TactonRecorderPlayer::PlayButtonPressed(tact::Buzzer &buzzer) {
 
 
 void TactonRecorderPlayer::LoopButtonPressed(tact::Buzzer &buzzer) {
-  if (state != State::playing)
-    return;
+  //if (state != State::playing)
+  //  return;
   loop_playback = !loop_playback;
   buzzer.PlayConfirm();
   SetState(state, true);

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -75,6 +75,12 @@ void TactonRecorderPlayer::RecordButtonPressed(tact::State &current_state, tact:
 void TactonRecorderPlayer::PlayButtonPressed(tact::Buzzer &buzzer) {
   actuator_driver->Update(0, 0);
   button_leds->Update(0);
+  if (state == State::playing) {
+    SetState(State::idle);
+    buzzer.PlayConfirm();
+    buzzer.PlayConfirm();
+    return;
+  }
   buzzer.PlayConfirm();
   time_start_milliseconds = millis();
   SetState(State::playing);

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -97,15 +97,11 @@ void TactonRecorderPlayer::LoopButtonPressed(tact::Buzzer &buzzer) {
 
 void TactonRecorderPlayer::RecordSample(tact::State &current_state, tact::Buzzer &buzzer) {
 
-  if ( state == State::playing) {
-    //actuator button is pressed during playback, this is not allowed
-    //buzzer.PlayFail();
+  if ( state != State::recording) {
+    //actuator button is only allowed during recording
+    if ( current_state.pressed_actuator_buttons != 0)
+      buzzer.PlayFail();
     return;
-  }
-
-  if ( state == State::idle) {
-    //directly start recording, if actuator button is pressed in idle mode
-    RecordButtonPressed(current_state, buzzer);
   }
 
   if ( current_state.slot >= TACTONS_COUNT_MAX)

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -19,11 +19,20 @@ void TactonRecorderPlayer::SetState(State state, bool force_display_update) {
   if (state != this->state || force_display_update == true) {
     switch(state) {
       case State::idle: 
-        display->DrawContentTeaser("idle");
+        
+        //if ( loop_playback == true )
+        //  display->DrawContentTeaser("idle");
+        //else
+          display->DrawContentTeaser("idle");
         actuator_driver->Update(0, 0);
         button_leds->Update(0);
         break;
-      case State::playing: display->DrawContentTeaser("play"); break;
+      case State::playing:
+        if ( loop_playback == true )
+          display->DrawContentTeaser("play\nloop on");
+        else
+          display->DrawContentTeaser("play\nloop off");
+        break;
       case State::recording: display->DrawContentTeaser("rec"); break;
     }
   }
@@ -72,6 +81,15 @@ void TactonRecorderPlayer::PlayButtonPressed(tact::Buzzer &buzzer) {
   #ifdef TACT_DEBUG
   Serial.printf("PlayButtonPressed(): time_start_milliseconds=%ld\n", time_start_milliseconds);
   #endif //TACT_DEBUG
+}
+
+
+void TactonRecorderPlayer::LoopButtonPressed(tact::Buzzer &buzzer) {
+  if (state != State::playing)
+    return;
+  loop_playback = !loop_playback;
+  buzzer.PlayConfirm();
+  SetState(state, true);
 }
 
 
@@ -124,6 +142,8 @@ void TactonRecorderPlayer::PlaySample(tact::State &current_state, tact::Buzzer &
     buzzer.PlayConfirm();
     buzzer.PlayConfirm();
     SetState(State::idle);
+    if (loop_playback == true)
+      PlayButtonPressed(buzzer);
     return;
   }
 

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -77,10 +77,15 @@ void TactonRecorderPlayer::PlayButtonPressed(tact::Buzzer &buzzer) {
 
 void TactonRecorderPlayer::RecordSample(tact::State &current_state, tact::Buzzer &buzzer) {
 
-  if ( state != State::recording) {
-    //actuator button is pressed during recording, this is not allowed
-    buzzer.PlayFail();
+  if ( state == State::playing) {
+    //actuator button is pressed during playback, this is not allowed
+    //buzzer.PlayFail();
     return;
+  }
+
+  if ( state == State::idle) {
+    //directly start recording, if actuator button is pressed in idle mode
+    RecordButtonPressed(current_state, buzzer);
   }
 
   if ( current_state.slot >= TACTONS_COUNT_MAX)

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -23,17 +23,18 @@ void TactonRecorderPlayer::SetState(State state, bool force_display_update) {
         //if ( loop_playback == true )
         //  display->DrawContentTeaser("idle");
         //else
-          display->DrawContentTeaser("idle");
+          display->DrawContentTeaserSingleLine("idle");
         actuator_driver->Update(0, 0);
         button_leds->Update(0);
         break;
       case State::playing:
         if ( loop_playback == true )
-          display->DrawContentTeaser("play\nloop on");
+          display->DrawContentTeaserDoubleLine("play", "loop on");
         else
-          display->DrawContentTeaser("play\nloop off");
+          display->DrawContentTeaserDoubleLine("play", "loop off");
         break;
-      case State::recording: display->DrawContentTeaser("rec"); break;
+      case State::recording: display->DrawContentTeaserSingleLine("rec");
+        break;
     }
   }
   this->state = state;

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -1,0 +1,126 @@
+#include "tactons.h"
+
+namespace tact {
+
+
+void TactonSample::SerialPrint() {
+  Serial.printf("TactonSample: time_milliseconds=%d  buttons_state=", time_milliseconds);
+  Serial.print(buttons_state, BIN);
+  Serial.printf("  amplitude=%d\n", amplitude_percent);
+}
+
+
+TactonRecorderPlayer::TactonRecorderPlayer() : tactons(TACTONS_COUNT_MAX) {
+}
+
+
+void TactonRecorderPlayer::Reset(void)  {
+  state = State::idle;
+  #ifdef TACT_DEBUG
+  Serial.println("actonRecorderPlayer::Reset");
+  #endif //TACT_DEBUG
+}
+
+
+void TactonRecorderPlayer::RecordButtonPressed(tact::State &current_state, tact::Buzzer &buzzer) {
+  if (state == State::recording) {
+    state = State::idle;
+    buzzer.PlayConfirm();
+    buzzer.PlayConfirm();
+    return;
+  }
+  tactons.at(current_state.slot).tacton_samples.clear();
+  //tactons.at(current_state.slot).tacton_samples.reserve(TACTON_SAMPLES_MAX);
+  time_start_milliseconds = millis();
+  state = State::recording;
+
+  buzzer.PlayConfirm();
+
+  #ifdef TACT_DEBUG
+  Serial.printf("RecordButtonPressed(): time_start_milliseconds=%ld\n", time_start_milliseconds);
+  #endif //TACT_DEBUG
+}
+
+
+void TactonRecorderPlayer::PlayButtonPressed(tact::Buzzer &buzzer) {
+  buzzer.PlayConfirm();
+  time_start_milliseconds = millis();
+  state = State::playing;
+  index_play_next = 0;
+
+  #ifdef TACT_DEBUG
+  Serial.printf("PlayButtonPressed(): time_start_milliseconds=%ld\n", time_start_milliseconds);
+  #endif //TACT_DEBUG
+}
+
+
+void TactonRecorderPlayer::RecordSample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, tact::SN74HC595 &button_leds) {
+
+  if ( state != State::recording) {
+    //actuator button is pressed during recording, this is not allowed
+    buzzer.PlayFail();
+    return;
+  }
+
+  if ( current_state.slot >= TACTONS_COUNT_MAX)
+    return;
+
+  TactonSample tactonSample;
+  tactonSample.time_milliseconds = millis() - time_start_milliseconds;
+  tactonSample.buttons_state = current_state.pressed_actuator_buttons;
+  tactonSample.amplitude_percent = current_state.amplitude_percent;
+
+  tactons.at(current_state.slot).tacton_samples.push_back(tactonSample);
+
+  button_leds.Update(current_state.pressed_actuator_buttons);
+  actuator_driver.Update(current_state.pressed_actuator_buttons, current_state.amplitude);
+
+  #ifdef TACT_DEBUG
+  tactonSample.SerialPrint();
+  #endif //TACT_DEBUG
+}
+
+
+void TactonRecorderPlayer::PlaySample(tact::State &current_state, tact::Buzzer &buzzer, tact::PCA9685 &actuator_driver, 
+                                      tact::SN74HC595 &button_leds, tact::LinearEncoder &amplitude_encoder) {
+
+  if ( state != State::playing) {
+    //buzzer.PlayFail();
+    return;
+  }
+
+  if ( current_state.slot >= TACTONS_COUNT_MAX)
+    return;
+
+  std::vector<TactonSample> *tacton_samples  = &tactons.at(current_state.slot).tacton_samples;
+
+  if ( index_play_next >= tacton_samples->size()) {
+    //last sample has been played
+    buzzer.PlayConfirm();
+    buzzer.PlayConfirm();
+    state = State::idle;
+    return;
+  }
+
+  TactonSample *tacton_latest = NULL;
+  unsigned long millis_current = millis() - time_start_milliseconds;
+  for (int i = index_play_next; i < tacton_samples->size(); i++) {
+    if (millis_current >= tacton_samples->at(i).time_milliseconds) {
+      tacton_latest = &tacton_samples->at(i);
+      index_play_next = i + 1;
+    } else {
+      break;
+    }
+  }
+
+  if ( tacton_latest != NULL ) {
+    actuator_driver.Update(tacton_latest->buttons_state, amplitude_encoder.PercentToLinearEncoder(tacton_latest->amplitude_percent));
+    button_leds.Update(tacton_latest->buttons_state);
+    #ifdef TACT_DEBUG
+    Serial.printf("sample %d/%d: ", index_play_next, tacton_samples->size());
+    tacton_latest->SerialPrint();
+    #endif //TACT_DEBUG
+  }
+}
+
+}

--- a/TACT/src/tactons.cpp
+++ b/TACT/src/tactons.cpp
@@ -61,7 +61,7 @@ void TactonRecorderPlayer::RecordButtonPressed(tact::State &current_state, tact:
   }
   tactons.at(current_state.slot).tacton_samples.clear();
   //tactons.at(current_state.slot).tacton_samples.reserve(TACTON_SAMPLES_MAX);
-  time_start_milliseconds = millis();
+  time_start_milliseconds = 0;
   SetState(State::recording);
 
   buzzer.PlayConfirm();
@@ -110,6 +110,10 @@ void TactonRecorderPlayer::RecordSample(tact::State &current_state, tact::Buzzer
 
   if ( current_state.slot >= TACTONS_COUNT_MAX)
     return;
+
+  //this avoids a time gap between start record and first actuator button press
+  if (time_start_milliseconds == 0)
+    time_start_milliseconds = millis();
 
   TactonSample tactonSample;
   tactonSample.time_milliseconds = millis() - time_start_milliseconds;


### PR DESCRIPTION
beeing in record play mode:
 board is in idle mode, pressing an actuator button is not allowed (long double beep tone)
 pressing menu button 1 always starts recording selected slot (short beep tone)
 pressing menu button 1 during recording stops recording going to idle (short double beep tone)
 pressing menu button 2 always starts playing selected slot (short beep tone) going to idle at end of tacton (short double beep tone)