### PR TITLE
fix(release): :rocket: hardcoded version tag

### DIFF
--- a/TACT/platformio.ini
+++ b/TACT/platformio.ini
@@ -8,8 +8,8 @@
 # The revision string is the shortened ID (7 HEX digits) of the most recent commit.
 # EXAMPLE: -DGIT_REV='"1a2b3c4"' -DGIT_TAG='"v1.0.0"'
 # Replace the next line with the line below (comment).
-build_flags = !python git_rev_macro.py
-#build_flags = -DGIT_REV='"rev_id"' -DGIT_TAG='"vX.Y.z"'
+#build_flags = !python git_rev_macro.py
+build_flags = -DGIT_REV='"TEI2021"' -DGIT_TAG='"v0.3.1"'
 
 # As there will be a couple of hardware revisions you have to
 # specify the board you want to compile for.


### PR DESCRIPTION
On Windows the automated parsing of the version and revision fails. For the sake of simplicity we hardcode the string for this release.